### PR TITLE
Pinning decorator and context manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,3 +86,24 @@ If you need to change the name of the cookie, use the ``MULTIDB_PINNING_COOKIE``
 setting::
 
     MULTIDB_PINNING_COOKIE = 'multidb_pin_writes'
+
+
+``use_master``
+==============
+
+``multidb.pinning.use_master`` is both a context manager and a decorator for
+wrapping code to use the master database. You can use it as a context manager::
+
+    from multidb.pinning import use_master
+
+    with use_master:
+        touch_the_database()
+    touch_another_database()
+
+or as a decorator::
+
+    from multidb.pinning import use_master
+
+    @use_master
+    def func(*args, **kw):
+        """Touches the master database."""

--- a/multidb/pinning.py
+++ b/multidb/pinning.py
@@ -1,7 +1,12 @@
 """An encapsulated thread-local variable that indicates whether future DB
 writes should be "stuck" to the master."""
 
+from functools import wraps
 import threading
+
+
+__all__ = ['this_thread_is_pinned', 'pin_this_thread', 'unpin_this_thread',
+           'use_master']
 
 
 _locals = threading.local()
@@ -28,3 +33,27 @@ def unpin_this_thread():
         del _locals.pinned
     except AttributeError:
         pass
+
+
+class UseMaster(object):
+    """A contextmanager/decorator to use the master database."""
+    old = False
+
+    def __call__(self, func):
+        @wraps(func)
+        def decorator(*args, **kw):
+            with self:
+                return func(*args, **kw)
+        return decorator
+
+    def __enter__(self):
+        self.old = this_thread_is_pinned()
+        pin_this_thread()
+
+    def __exit__(self, type, value, tb):
+        if not self.old:
+            unpin_this_thread()
+        if any((type, value, tb)):
+            raise type, value, tb
+
+use_master = UseMaster()


### PR DESCRIPTION
Adds a `@pinned` decorator and a `with pinning():` context manager. I got sick of `(un)pin_this_thread()` in tasks.
