### PR TITLE
Allows views to indicate that they do--or have done--a DB write.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,12 @@ length of time.
 Caveats
 =======
 
-``PinningRouterMiddleware`` identifies database writes solely by request type,
-assuming that any ``POST`` request is a write.
+``PinningRouterMiddleware`` identifies database writes primarily by request
+type, assuming that any ``POST`` request is a write. You can indicate that
+any view triggers a database write by using the ``multidb.db_write`` decorator.
+You can also manually set ``response._db_write = True`` to indicate that a
+write occurred. Either one of these will cause the same result as if the
+request was a ``POST``.
 
 This package makes no attempt to redirect database activity that occurs after a
 write but during the same request. You application is responsible for manually

--- a/multidb/__init__.py
+++ b/multidb/__init__.py
@@ -32,7 +32,7 @@ import random
 
 from django.conf import settings
 
-from .pinning import this_thread_is_pinned
+from .pinning import this_thread_is_pinned, db_write
 
 
 DEFAULT_DB_ALIAS = 'default'

--- a/multidb/middleware.py
+++ b/multidb/middleware.py
@@ -39,7 +39,7 @@ class PinningRouterMiddleware(object):
         Even if it was already set, reset its expiration time.
 
         """
-        if request.method == 'POST':
+        if request.method == 'POST' or getattr(response, '_db_write', False):
             response.set_cookie(PINNING_COOKIE, value='y',
                                 max_age=PINNING_SECONDS)
         return response

--- a/multidb/pinning.py
+++ b/multidb/pinning.py
@@ -57,3 +57,12 @@ class UseMaster(object):
             raise type, value, tb
 
 use_master = UseMaster()
+
+
+def db_write(fn):
+    @wraps(fn)
+    def _wrapped(*args, **kw):
+        response = fn(*args, **kw)
+        response._db_write = True
+        return response
+    return _wrapped


### PR DESCRIPTION
Pay attention to `response._db_write` and provide a decorator to set it to
True. If the attribute exists and is true, set the pinning cookie as if the
request had been a `POST`.

If a view _may_ do a DB write, set the attribute on the response object
if necessary before returning it.

Just opening a pull request so I can use the fancy merge button.
