### PR TITLE
make use_master thread safe

### DIFF
--- a/multidb/pinning.py
+++ b/multidb/pinning.py
@@ -34,8 +34,6 @@ def unpin_this_thread():
 
 class UseMaster(object):
     """A contextmanager/decorator to use the master database."""
-    old = False
-
     def __call__(self, func):
         @wraps(func)
         def decorator(*args, **kw):
@@ -44,11 +42,11 @@ class UseMaster(object):
         return decorator
 
     def __enter__(self):
-        self.old = this_thread_is_pinned()
+        _locals.old = this_thread_is_pinned()
         pin_this_thread()
 
     def __exit__(self, type, value, tb):
-        if not self.old:
+        if not _locals.old:
             unpin_this_thread()
 
 use_master = UseMaster()


### PR DESCRIPTION
Hopefully the test will be enough to explain why this is an issue. The gist is that state was being stored in an object used in multiple threads.