### PR TITLE
fix test typo, run use_master reset tests

### DIFF
--- a/multidb/tests.py
+++ b/multidb/tests.py
@@ -186,7 +186,7 @@ class ContextDecoratorTests(TestCase):
             assert this_thread_is_pinned()
         assert not this_thread_is_pinned()
 
-    def text_context_manager_resets(self):
+    def test_context_manager_resets(self):
         pin_this_thread()
         assert this_thread_is_pinned()
         with use_master:


### PR DESCRIPTION
This test wasn't being collected & run because it had the wrong prefix.