### PR TITLE
Add tox & fix tests for Django >= 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 sudo: false
 language: python
-python:
- - "2.6"
- - "2.7"
- - "3.2"
- - "3.3"
- - "3.4"
-install: pip install -r requirements.txt
-script: ./run.sh test
+python: 2.7
+env:
+    - TOX_ENV=py27-django15
+    - TOX_ENV=py27-django16
+    - TOX_ENV=py27-django17
+    - TOX_ENV=py27-django18
+    - TOX_ENV=py33-django17
+    - TOX_ENV=py33-django18
+    - TOX_ENV=py34-django17
+    - TOX_ENV=py34-django18
+    - TOX_ENV=flake8
+script: tox -e $TOX_ENV
+install:
+    - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,46 @@
 sudo: false
 language: python
-python: 2.7
-env:
-    - TOX_ENV=py27-django15
-    - TOX_ENV=py27-django16
-    - TOX_ENV=py27-django17
-    - TOX_ENV=py27-django18
-    - TOX_ENV=py33-django17
-    - TOX_ENV=py33-django18
-    - TOX_ENV=py34-django17
-    - TOX_ENV=py34-django18
-    - TOX_ENV=flake8
+
+matrix:
+    include:
+      - python: "2.7"
+        env: TOX_ENV=py27-django15
+      - python: "2.7"
+        env: TOX_ENV=py27-django16
+      - python: "2.7"
+        env: TOX_ENV=py27-django17
+      - python: "2.7"
+        env: TOX_ENV=py27-django18
+      - python: "2.7"
+        env: TOX_ENV=py27-django19
+      - python: "2.7"
+        env: TOX_ENV=py27-django110
+      - python: "3.3"
+        env: TOX_ENV=py33-django17
+      - python: "3.3"
+        env: TOX_ENV=py33-django18
+      - python: "3.4"
+        env: TOX_ENV=py34-django17
+      - python: "3.4"
+        env: TOX_ENV=py34-django18
+      - python: "3.4"
+        env: TOX_ENV=py34-django19
+      - python: "3.4"
+        env: TOX_ENV=py34-django110
+      - python: "3.5"
+        env: TOX_ENV=py35-django18
+      - python: "3.5"
+        env: TOX_ENV=py35-django19
+      - python: "3.5"
+        env: TOX_ENV=py35-django110
+      - python: "3.6"
+        env: TOX_ENV=py36-django18
+      - python: "3.6"
+        env: TOX_ENV=py36-django19
+      - python: "3.6"
+        env: TOX_ENV=py36-django110
+      - python: "2.7"
+        env: TOX_ENV=flake8
 script: tox -e $TOX_ENV
 install:
     - pip install tox

--- a/README.rst
+++ b/README.rst
@@ -118,3 +118,9 @@ To run the tests, you'll need to install the development requirements::
 
     pip install -r requirements.txt
     ./run.sh test
+
+Alternatively, you can run the tests with several versions of Django
+and Python using tox:
+
+    pip install tox
+    tox

--- a/olddjango_requirements.txt
+++ b/olddjango_requirements.txt
@@ -1,0 +1,2 @@
+django-nose==1.4.2
+flake8==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Django==1.5.5
-django-nose==1.2
+django-nose==1.4.2
 nose==1.3.0
 flake8==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django-nose==1.4.2
+django-nose==1.4.4
 flake8==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 django-nose==1.4.2
-nose==1.3.0
 flake8==2.1.0

--- a/test_settings.py
+++ b/test_settings.py
@@ -3,6 +3,11 @@
 SECRET_KEY = 'dummy'
 TEST_RUNNER = 'django_nose.runner.NoseTestSuiteRunner'
 
+MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware'
+)
+
 # The default database should point to the master.
 DATABASES = {
     'default': {

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = flake8,py27-django{15,16,17,18},py{33,34}-django{17,18}
+
+[testenv]
+deps =
+    django15: Django>=1.5,<1.6
+    django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
+    -rrequirements.txt
+    .
+commands =
+    ./run.sh test
+    pip freeze
+
+[testenv:flake8]
+deps =
+    -rrequirements.txt
+
+commands = ./run.sh check

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27-django{15,16,17,18},py{33,34}-django{17,18}
+envlist = flake8,py27-django{15,16,17,18,19,110},py{33,34}-django{17,18},py{34}-django{19,110},py{35,36}-django{18,19,110}
 
 [testenv]
 deps =
@@ -7,11 +7,23 @@ deps =
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
     -rrequirements.txt
-    .
+
 commands =
     ./run.sh test
     pip freeze
+
+[testenv:py27-django15]
+deps =
+    django15: Django>=1.5,<1.6
+    -rolddjango_requirements.txt
+
+[testenv:py27-django16]
+deps =
+    django16: Django>=1.6,<1.7
+    -rolddjango_requirements.txt
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Thanks to tox it's easy to keep track of the current support of different versions of Django & Python.
