### PR TITLE
Router that ensures the same DB is used within a request

### DIFF
--- a/multidb/__init__.py
+++ b/multidb/__init__.py
@@ -34,7 +34,7 @@ from distutils.version import LooseVersion
 import django
 from django.conf import settings
 
-from .pinning import this_thread_is_pinned, db_write  # noqa
+from .pinning import this_thread_is_pinned, db_write, get_current_db, set_current_db  # noqa
 
 
 DEFAULT_DB_ALIAS = 'default'

--- a/multidb/pinning.py
+++ b/multidb/pinning.py
@@ -43,7 +43,7 @@ def clean_current_db():
 
 
 def get_current_db():
-    return _locals.current_db
+    return getattr(_locals, "current_db", None)
 
 
 def set_current_db(dbname):

--- a/multidb/pinning.py
+++ b/multidb/pinning.py
@@ -9,7 +9,13 @@ __all__ = ['this_thread_is_pinned', 'pin_this_thread', 'unpin_this_thread',
            'use_master', 'db_write']
 
 
-_locals = threading.local()
+try:
+    from gevent.local import local
+except ImportError:
+    local = threading.local
+
+
+_locals = local()
 
 
 def this_thread_is_pinned():
@@ -30,6 +36,18 @@ def unpin_this_thread():
 
     """
     _locals.pinned = False
+
+
+def clean_current_db():
+    _locals.current_db = None
+
+
+def get_current_db():
+    return _locals.current_db
+
+
+def set_current_db(dbname):
+    _locals.current_db = dbname
 
 
 class UseMaster(object):


### PR DESCRIPTION
Uses thread local storage (o gevent local storage if available) to store the current DB in use. In the first call for a request, it sets the current db in use and returns always the same.

At the start of each request, the middleware cleans the current DB.