### PR TITLE
Adding method allow_migrate on MasterSlaveRouter

### DIFF
--- a/multidb/__init__.py
+++ b/multidb/__init__.py
@@ -98,3 +98,9 @@ class PinningMasterSlaveRouter(MasterSlaveRouter):
         """Send reads to slaves in round-robin unless this thread is "stuck" to
         the master."""
         return DEFAULT_DB_ALIAS if this_thread_is_pinned() else get_slave()
+    
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        """Determine if the migration operation is allowed to run on the database with alias db."""
+        if db in settings.SLAVE_DATABASES:
+            return False
+        return True

--- a/multidb/__init__.py
+++ b/multidb/__init__.py
@@ -80,7 +80,7 @@ class MasterSlaveRouter(object):
         return db == DEFAULT_DB_ALIAS
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
-        """Determine if the migration operation is allowed to run on the database with alias db."""
+        """Check if the migration operation is allowed to run."""
         if db in settings.SLAVE_DATABASES:
             return False
         return True
@@ -100,7 +100,7 @@ class PinningMasterSlaveRouter(MasterSlaveRouter):
         return DEFAULT_DB_ALIAS if this_thread_is_pinned() else get_slave()
     
     def allow_migrate(self, db, app_label, model_name=None, **hints):
-        """Determine if the migration operation is allowed to run on the database with alias db."""
+        """Check if the migration operation is allowed to run."""
         if db in settings.SLAVE_DATABASES:
             return False
         return True

--- a/multidb/__init__.py
+++ b/multidb/__init__.py
@@ -79,7 +79,7 @@ class MasterSlaveRouter(object):
         """Only allow syncdb on the master."""
         return db == DEFAULT_DB_ALIAS
 
-    def allow_migrate(db, app_label, model_name=None, **hints):
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
         """Determine if the migration operation is allowed to run on the database with alias db."""
         if db in settings.SLAVE_DATABASES:
             return False

--- a/multidb/__init__.py
+++ b/multidb/__init__.py
@@ -79,6 +79,11 @@ class MasterSlaveRouter(object):
         """Only allow syncdb on the master."""
         return db == DEFAULT_DB_ALIAS
 
+    def allow_migrate(db, app_label, model_name=None, **hints):
+        """Determine if the migration operation is allowed to run on the database with alias db."""
+        if db in settings.SLAVE_DATABASES:
+            return False
+        return True
 
 class PinningMasterSlaveRouter(MasterSlaveRouter):
     """Router that sends reads to master iff a certain flag is set. Writes

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-multidb-router',
-    version='0.6',
+    version='0.7',
     description='Round-robin multidb router for Django.',
     long_description=open('README.rst').read(),
     author='Jeff Balogh',


### PR DESCRIPTION
Prevents it from breaking with Django 1.8.*
