### PR TITLE
Implement allow_migrate() to support django migrations properly.

### DIFF
--- a/multidb/__init__.py
+++ b/multidb/__init__.py
@@ -75,13 +75,16 @@ class MasterSlaveRouter(object):
         """Allow all relations, so FK validation stays quiet."""
         return True
 
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        return db == DEFAULT_DB_ALIAS
+
     def allow_syncdb(self, db, model):
         """Only allow syncdb on the master."""
         return db == DEFAULT_DB_ALIAS
 
 
 class PinningMasterSlaveRouter(MasterSlaveRouter):
-    """Router that sends reads to master iff a certain flag is set. Writes
+    """Router that sends reads to master if a certain flag is set. Writes
     always go to master.
 
     Typically, we set a cookie in middleware for certain request HTTP methods

--- a/multidb/tests.py
+++ b/multidb/tests.py
@@ -36,6 +36,13 @@ class MasterSlaveRouterTests(TestCase):
         assert router.allow_syncdb(DEFAULT_DB_ALIAS, None)
         assert not router.allow_syncdb(get_slave(), None)
 
+    def test_allow_migrate(self):
+        """Make sure allow_migrate() does the right thing for both masters and
+        slaves"""
+        router = MasterSlaveRouter()
+        assert router.allow_migrate(DEFAULT_DB_ALIAS, 'dummy')
+        assert not router.allow_migrate(get_slave(), 'dummy')
+
 
 class SettingsTests(TestCase):
     """Tests for settings defaults"""


### PR DESCRIPTION
Fix #33