### PR TITLE
Version 0.9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,12 @@
 CHANGELOG
 =========
 
-master
+Version 0.9
 -----------
 
-- Drop support of Python 3.4
+- Deprecate master/slave terminology and switch to replica. #44
+- Fix bug and warn when REPLICA_DATABASES is not defined. #39
+- Drop support of Python 3.4. #43 etc
 - Confirm support of Python 3.7
 - Drop support of Django 1.8
 - Drop support of Django 1.10

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,9 +21,9 @@ copyright = '2019, The Zamboni Collective'
 # built documents.
 #
 # The short X.Y version.
-version = '0.8'
+version = '0.9'
 # The full version, including alpha/beta/rc tags.
-release = '0.8.0'
+release = '0.9.0'
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.

--- a/multidb/__init__.py
+++ b/multidb/__init__.py
@@ -36,6 +36,9 @@ from django.conf import settings
 from .pinning import this_thread_is_pinned, db_write  # noqa
 
 
+VERSION = (0, 9, 0)
+__version__ = '.'.join(map(str, VERSION))
+
 DEFAULT_DB_ALIAS = 'default'
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-multidb-router',
-    version='0.8',
+    version='0.9',
     description='Round-robin multidb router for Django.',
     long_description=open('README.rst').read(),
     author='Jeff Balogh',


### PR DESCRIPTION
Version 0.9
-----------

- Deprecate master/slave terminology and switch to replica. #44
- Fix bug and warn when REPLICA_DATABASES is not defined. #39
- Drop support of Python 3.4. #43 etc
- Confirm support of Python 3.7
- Drop support of Django 1.8
- Drop support of Django 1.10
- Confirm support of Django 2.0
- Confirm support of Django 2.1