### PR TITLE
Allow Setting Pinning Cookie Attributes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,8 @@ the session and CSRF cookies::
     MULTIDB_PINNING_COOKIE_HTTPONLY = False
     MULTIDB_PINNING_COOKIE_SAMESITE = 'Lax'
 
+Note: the 'SameSite' attribute is only `available on django 2.1 and higher
+<https://docs.djangoproject.com/en/2.1/releases/2.1/>`_.
 
 ``use_primary_db``
 ==============

--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,15 @@ setting::
     MULTIDB_PINNING_COOKIE = 'multidb_pin_writes'
 
 
+You may also set the 'Secure', 'HttpOnly', and 'SameSite' cookie attributes by
+using the following settings. These settings are based on Django's settings for
+the session and CSRF cookies::
+
+    MULTIDB_PINNING_COOKIE_SECURE = False
+    MULTIDB_PINNING_COOKIE_HTTPONLY = False
+    MULTIDB_PINNING_COOKIE_SAMESITE = 'Lax'
+
+
 ``use_primary_db``
 ==============
 

--- a/multidb/middleware.py
+++ b/multidb/middleware.py
@@ -13,7 +13,10 @@ from .pinning import pin_this_thread, unpin_this_thread
 # The name of the cookie that directs a request's reads to the master DB
 PINNING_COOKIE = getattr(settings, 'MULTIDB_PINNING_COOKIE',
                          'multidb_pin_writes')
-
+# Determine cookie attributes based on settings, or their defaults.
+PINNING_COOKIE_HTTPONLY = getattr(settings, 'MULTIDB_PINNING_COOKIE_HTTPONLY', False)
+PINNING_COOKIE_SAMESITE = getattr(settings, 'MULTIDB_PINNING_COOKIE_SAMESITE', "Lax")
+PINNING_COOKIE_SECURE = getattr(settings, 'MULTIDB_PINNING_COOKIE_SECURE', False)
 
 # The number of seconds for which reads are directed to the master DB after a
 # write
@@ -54,5 +57,8 @@ class PinningRouterMiddleware(MiddlewareMixin):
         if (request.method not in READ_ONLY_METHODS or
                 getattr(response, '_db_write', False)):
             response.set_cookie(PINNING_COOKIE, value='y',
-                                max_age=PINNING_SECONDS)
+                                max_age=PINNING_SECONDS,
+                                secure=PINNING_COOKIE_SECURE,
+                                httponly=PINNING_COOKIE_HTTPONLY,
+                                samesite=PINNING_COOKIE_SAMESITE)
         return response

--- a/multidb/middleware.py
+++ b/multidb/middleware.py
@@ -56,9 +56,19 @@ class PinningRouterMiddleware(MiddlewareMixin):
         """
         if (request.method not in READ_ONLY_METHODS or
                 getattr(response, '_db_write', False)):
-            response.set_cookie(PINNING_COOKIE, value='y',
-                                max_age=PINNING_SECONDS,
-                                secure=PINNING_COOKIE_SECURE,
-                                httponly=PINNING_COOKIE_HTTPONLY,
-                                samesite=PINNING_COOKIE_SAMESITE)
+
+            # Older versions of Django don't support the SameSite attribute on
+            # cookies. If setting the cookie fails with a TypeError, then try
+            # setting the cookie without the samesite attribute.
+            try:
+                response.set_cookie(PINNING_COOKIE, value='y',
+                                    max_age=PINNING_SECONDS,
+                                    secure=PINNING_COOKIE_SECURE,
+                                    httponly=PINNING_COOKIE_HTTPONLY,
+                                    samesite=PINNING_COOKIE_SAMESITE)
+            except TypeError:
+                response.set_cookie(PINNING_COOKIE, value='y',
+                                    max_age=PINNING_SECONDS,
+                                    secure=PINNING_COOKIE_SECURE,
+                                    httponly=PINNING_COOKIE_HTTPONLY)
         return response

--- a/multidb/tests.py
+++ b/multidb/tests.py
@@ -15,8 +15,9 @@ import multidb.pinning
 
 from multidb import (DEFAULT_DB_ALIAS, ReplicaRouter, PinningReplicaRouter,
                      get_replica)
-from multidb.middleware import (PINNING_COOKIE, PINNING_SECONDS,
-                                PinningRouterMiddleware)
+from multidb.middleware import (PINNING_COOKIE, PINNING_COOKIE_HTTPONLY,
+                                PINNING_COOKIE_SAMESITE, PINNING_COOKIE_SECURE,
+                                PINNING_SECONDS, PinningRouterMiddleware)
 from multidb.pinning import (this_thread_is_pinned, pin_this_thread,
                              unpin_this_thread, use_primary_db, db_write)
 
@@ -58,6 +59,12 @@ class SettingsTests(TestCase):
     def test_pinning_seconds_default(self):
         """Make sure the cookie age has the right default."""
         eq_(PINNING_SECONDS, 15)
+
+    def test_pinning_cookie_default_attributes(self):
+        """Check that the pinning cookie has the right default attributes."""
+        eq_(PINNING_COOKIE_SECURE, False)
+        eq_(PINNING_COOKIE_HTTPONLY, False)
+        eq_(PINNING_COOKIE_SAMESITE, 'Lax')
 
 
 class PinningTests(UnpinningTestCase):


### PR DESCRIPTION
This pull request allows users to set the pinning cookie's 'Secure', 'HttpOnly', and 'SameSite' attributes by using settings, which are based on Django's `CSRF_COOKIE_SECURE`, `CSRF_COOKIE_HTTPONLY`, and `CSRF_COOKIE_SAMESITE` settings.
The defaults for these settings keep the current behavior: not Secure, not HttpOnly, and 'Lax' SameSite (currently, the SameSite attribute is unset, which [should default to 'Lax' in browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite)).

A part of this work also changes the `PINNING_COOKIE` and `PINNING_SECONDS` in `multidb/middleware.py` to be functions, so they can be tested more easily.