### PR TITLE
Add support for nested context manager use

### DIFF
--- a/multidb/pinning.py
+++ b/multidb/pinning.py
@@ -34,7 +34,7 @@ def unpin_this_thread():
 
 
 class UsePrimaryDB(object):
-    """A contextmanager/decorator to use the master database."""
+    """A contextmanager/decorator to use the primary database."""
     def __call__(self, func):
         @wraps(func)
         def decorator(*args, **kw):
@@ -43,11 +43,12 @@ class UsePrimaryDB(object):
         return decorator
 
     def __enter__(self):
-        _locals.old = this_thread_is_pinned()
+        _locals.old = getattr(_locals, 'old', [])
+        _locals.old.append(this_thread_is_pinned())
         pin_this_thread()
 
     def __exit__(self, type, value, tb):
-        if not _locals.old:
+        if not _locals.old.pop():
             unpin_this_thread()
 
 

--- a/multidb/tests.py
+++ b/multidb/tests.py
@@ -202,6 +202,22 @@ class UsePrimaryDBTests(TestCase):
         check()
         assert not this_thread_is_pinned()
 
+    def test_decorator_nested(self):
+        @use_primary_db
+        def check_inner():
+            assert this_thread_is_pinned()
+
+        @use_primary_db
+        def check_outer():
+            assert this_thread_is_pinned()
+            check_inner()
+            assert this_thread_is_pinned()
+
+        unpin_this_thread()
+        assert not this_thread_is_pinned()
+        check_outer()
+        assert not this_thread_is_pinned()
+
     def test_decorator_resets(self):
         @use_primary_db
         def check():
@@ -211,6 +227,22 @@ class UsePrimaryDBTests(TestCase):
         check()
         assert this_thread_is_pinned()
 
+    def test_decorator_resets_nested(self):
+        @use_primary_db
+        def check_inner():
+            assert this_thread_is_pinned()
+
+        @use_primary_db
+        def check_outer():
+            assert this_thread_is_pinned()
+            check_inner()
+            assert this_thread_is_pinned()
+
+        pin_this_thread()
+        assert this_thread_is_pinned()
+        check_outer()
+        assert this_thread_is_pinned()
+
     def test_context_manager(self):
         unpin_this_thread()
         assert not this_thread_is_pinned()
@@ -218,10 +250,30 @@ class UsePrimaryDBTests(TestCase):
             assert this_thread_is_pinned()
         assert not this_thread_is_pinned()
 
+    def test_context_manager_nested(self):
+        unpin_this_thread()
+        assert not this_thread_is_pinned()
+        with use_primary_db:
+            assert this_thread_is_pinned()
+            with use_primary_db:
+                assert this_thread_is_pinned()
+            assert this_thread_is_pinned()
+        assert not this_thread_is_pinned()
+
     def test_context_manager_resets(self):
         pin_this_thread()
         assert this_thread_is_pinned()
         with use_primary_db:
+            assert this_thread_is_pinned()
+        assert this_thread_is_pinned()
+
+    def test_context_manager_resets_nested(self):
+        pin_this_thread()
+        assert this_thread_is_pinned()
+        with use_primary_db:
+            assert this_thread_is_pinned()
+            with use_primary_db:
+                assert this_thread_is_pinned()
             assert this_thread_is_pinned()
         assert this_thread_is_pinned()
 


### PR DESCRIPTION
This PR adds support for nested use of the UsePrimaryDB context manager. It does this by storing a stack of pinning values locally in the thread and popping each value as the stack unwinds.