### PR TITLE
Bump version to django-multidb-router 0.11

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,19 @@
 CHANGELOG
 =========
 
+Version 0.11
+-----------
+
+- Drop support for Python 3.8 #64
+- Drop support for Django 3.2, 4.0, 4.1, 5.0 #64
+- Confirm support for Python 3.11, 3.12, 3.13 #63
+- Confirm support for Django 5.0, 5.1, 5.2 #63
+- Update CI badge #60
+- Remove django-nose completely #59
+- Confirm support for Python 3.10 #58
+- Confirm support for Django 4.0, 4.1, 4.2 #58
+- Fix Trove classifiers & minimum Django version #55
+
 Version 0.10
 ------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,9 +21,9 @@ copyright = '2019, The Zamboni Collective'
 # built documents.
 #
 # The short X.Y version.
-version = '0.10'
+version = '0.11'
 # The full version, including alpha/beta/rc tags.
-release = '0.10.0'
+release = '0.11.0'
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.

--- a/multidb/__init__.py
+++ b/multidb/__init__.py
@@ -36,7 +36,7 @@ from django.conf import settings
 from .pinning import this_thread_is_pinned, db_write  # noqa
 
 
-VERSION = (0, 10, 0)
+VERSION = (0, 11, 0)
 __version__ = '.'.join(map(str, VERSION))
 
 DEFAULT_DB_ALIAS = 'default'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-multidb-router',
-    version='0.10',
+    version='0.11',
     description='Round-robin multidb router for Django.',
     long_description=open('README.rst').read(),
     author='Jeff Balogh',


### PR DESCRIPTION
## Overview

This PR prepares a new version (v0.11) release of django-multidb-router.

## Changes

- Update version to 0.11.0 (setup.py, conf.py, `__init__.py`)
- Add Python/Django support implementation
- Update CHANGELOG

## Review Points
Please check the following during review:

- Are there any missing update location files
- If the CHANGELOG content is appropriate or not.

## Target PR's

I understand that the following content has been incorporated since the last release:
cf. https://github.com/jbalogh/django-multidb-router/commits/master/

- #64 
- #63 
- #60 
- #59 
- #58 
- #55 

## Related Issue
Fixes #61